### PR TITLE
Forcing date format to match CloudTrail-Tracker's date parsing

### DIFF
--- a/src/components/dashboard/Dashboard.vue
+++ b/src/components/dashboard/Dashboard.vue
@@ -152,9 +152,9 @@ export default {
 			var _this = this;
 			if(this.simpleSelectModel=="last hour"){
 				this.end_date = moment().add(-2, "hour");	 
-				this.end_date = this.end_date.format("YYYY-MM-DDTHH:mm:ss");
+				this.end_date = this.end_date.format("YYYY-MM-DDTHH:mm:ss[Z]");
 				this.start_date = moment().add(-3, "hour");
-				this.start_date = this.start_date.format("YYYY-MM-DDTHH:mm:ss");
+				this.start_date = this.start_date.format("YYYY-MM-DDTHH:mm:ss[Z]");
 					// axios.get("https://api.cursocloudaws.net/tracker/scan?from=" +this.start_date +"&to=" +this.end_date)
 					// // axios.get("https://api.cursocloudaws.net/tracker/scan?from=2018-06-24T19:00:44&to=2018-06-24T19:30:44")
 					// .then(function(resp) {						
@@ -164,9 +164,9 @@ export default {
 
 				}else if(this.simpleSelectModel=="last six hours"){
 				this.end_date = moment().add(-2, "hour");	 
-				this.end_date = this.end_date.format("YYYY-MM-DDTHH:mm:ss");
+				this.end_date = this.end_date.format("YYYY-MM-DDTHH:mm:ss[Z]");
 				this.start_date = moment().add(-10, "hour");
-				this.start_date = this.start_date.format("YYYY-MM-DDTHH:mm:ss");
+				this.start_date = this.start_date.format("YYYY-MM-DDTHH:mm:ss[Z]");
 					// axios.get("https://api.cursocloudaws.net/tracker/scan?from=" +this.start_date +"&to=" +this.end_date)
 					// .then(function(resp) {
 						


### PR DESCRIPTION
CloudTrail-Tracker's Query Lambda function expects dates in the following format: 2019-10-05T11:33:28Z.

The current version of CloudTrail-Tracker-UI sometimes emits dates using the following format: 2019-10-05T11:33:28+02:00, which results in an error in the Query Lambda function.

The changes allow to always emit the Z.